### PR TITLE
#24 탈퇴한 회원은 인증 대상에서 제외되도록 설정

### DIFF
--- a/src/main/java/com/t3t/authenticationapi/account/repository/AccountRepository.java
+++ b/src/main/java/com/t3t/authenticationapi/account/repository/AccountRepository.java
@@ -8,6 +8,6 @@ public interface AccountRepository extends JpaRepository<Account, String> {
     @Query("SELECT a.id as username, m.id as userId , b.password as password, m.role as role FROM Account a " +
             "INNER JOIN a.member m " +
             "INNER JOIN BookstoreAccount b ON a.id = b.id " +
-            "WHERE a.id = :id")
+            "WHERE a.id = :id AND a.deleted = 0")
     UserEntityDto loadUserEntity(String id);
 }


### PR DESCRIPTION
## 탈퇴 회원 인증 
- https://github.com/nhnacademy-be5-T3Team/authentication-api/issues/24
- [x] 탈퇴된 회원은 UserDetailService 에서 조회 요청 시 제외하여 인증 불가능하도록 처리함